### PR TITLE
Better way to highlight non-Latin searches

### DIFF
--- a/chrome/content/feedview.js
+++ b/chrome/content/feedview.js
@@ -1256,7 +1256,7 @@ EntryView.prototype = {
     },
 
     _highlightSearchTerms: function EntryView__highlightSearchTerms(aElement) {
-        for (let term in this.feedView.query.searchString.match(/[A-Za-z0-9]+/g)) {
+        for (let term in this.feedView.query.searchString.match(/\S+/g)) {
             let searchRange = this.feedView.document.createRange();
             searchRange.setStart(aElement, 0);
             searchRange.setEnd(aElement, aElement.childNodes.length);


### PR DESCRIPTION
Testcase: http://forum.mozilla-russia.org/extern.php?action=new&type=RSS&fid=21&res=site (try search for any Cyrillic word).
May be related to #8.
