### PR TITLE
Use grayscale icon, if all feeds are readed

### DIFF
--- a/chrome/content/brief-overlay.js
+++ b/chrome/content/brief-overlay.js
@@ -229,6 +229,10 @@ const Brief = {
         query.getEntryCount(function(unreadEntriesCount) {
             Brief.statusCounter.value = unreadEntriesCount;
             Brief.statusCounter.hidden = (unreadEntriesCount == 0);
+            if (unreadEntriesCount > 0)
+                Brief.toolbarbutton.removeAttribute("brief_noUnread");
+            else
+                Brief.toolbarbutton.setAttribute("brief_noUnread", "true");
         })
     },
 

--- a/chrome/skin/overlay.css
+++ b/chrome/skin/overlay.css
@@ -3,6 +3,10 @@
     -moz-box-align: center;
     -moz-box-orient: horizontal;
 }
+#brief-button[brief_noUnread] {
+    opacity: 0.85;
+    filter: url("chrome://mozapps/skin/extensions/extensions.svg#greyscale");
+}
 
 toolbar[iconsize=small] #brief-button {
     list-style-image: url(chrome://digest/skin/feed-icon-16x16.png);


### PR DESCRIPTION
I requested this some years (d'oh!) ago for Brief (and just applied the patch for my local copy after all):
http://web.archive.org/web/20120109021913/http://brief.mozdev.org/drupal/node/824?page=1#comment-3424
