### PR TITLE
complete month's name modified

### DIFF
--- a/chrome/content/feedview.js
+++ b/chrome/content/feedview.js
@@ -1256,11 +1256,11 @@ EntryView.prototype = {
                 break;
 
             case currentDate.getFullYear() === this.date.getFullYear():
-                string = this.date.toLocaleFormat('%d %b') + time;
+                string = this.date.toLocaleFormat('%d %B') + time;
                 break;
 
             default:
-                string = this.date.toLocaleFormat('%d %b %Y') + time;
+                string = this.date.toLocaleFormat('%d %B %Y') + time;
                 break;
         }
 


### PR DESCRIPTION
In my opinion displaying the complete month's name is better that the partial (the first 3 char).
It's my opinion, if u disagree reject the pull request (it's ur project and i'm contributing with ideas)
;)

a-little-help
