### PR TITLE
Ensure only one instance of some dialogs

### DIFF
--- a/chrome/content/brief-overlay.js
+++ b/chrome/content/brief-overlay.js
@@ -5,6 +5,7 @@ const Brief = {
     RELEASE_NOTES_VERSION_REGEXP: /^\w+\.\w+/,
 
     BRIEF_URL: 'chrome://digest/content/brief.xul',
+    BRIEF_OPTIONS_URL: 'chrome://digest/content/options/options.xul',
     BRIEF_FAVICON_URL: 'chrome://digest/skin/feed-icon-16x16.png',
 
     get statusCounter() document.getElementById('brief-status-counter'),
@@ -88,12 +89,20 @@ const Brief = {
     },
 
     showOptions: function cmd_showOptions() {
+        let windows = Services.wm.getEnumerator(null);
+        while (windows.hasMoreElements()) {
+            let win = windows.getNext();
+            if (win.document.documentURI == Brief.BRIEF_OPTIONS_URL) {
+                win.focus();
+                return;
+            }
+        }
+
         let instantApply = Services.prefs.getBoolPref('browser.preferences.instantApply');
         let features = 'chrome,titlebar,toolbar,centerscreen,resizable,';
         features += instantApply ? 'modal=no,dialog=no' : 'modal';
 
-        window.openDialog('chrome://digest/content/options/options.xul', 'Digest options',
-                          features);
+        window.openDialog(Brief.BRIEF_OPTIONS_URL, 'Digest options', features);
     },
 
     onTabLoad: function Brief_onTabLoad(aEvent) {

--- a/chrome/content/brief.js
+++ b/chrome/content/brief.js
@@ -103,12 +103,22 @@ let Commands = {
     },
 
     openOptions: function cmd_openOptions(aPaneID) {
+        let url = 'chrome://digest/content/options/options.xul';
+
+        let windows = Services.wm.getEnumerator(null);
+        while (windows.hasMoreElements()) {
+            let win = windows.getNext();
+            if (win.document.documentURI == url) {
+                win.focus();
+                return;
+            }
+        }
+
         let instantApply = Services.prefs.getBoolPref('browser.preferences.instantApply');
         let features = 'chrome,titlebar,toolbar,centerscreen,resizable,';
         features += instantApply ? 'modal=no,dialog=no' : 'modal';
 
-        window.openDialog('chrome://digest/content/options/options.xul', 'Digest options',
-                          features, aPaneID);
+        window.openDialog(url, 'Digest options', features, aPaneID);
     },
 
     markViewRead: function cmd_markViewRead() {
@@ -251,9 +261,19 @@ let Commands = {
     },
 
     displayShortcuts: function cmd_displayShortcuts() {
+        let url = 'chrome://digest/content/keyboard-shortcuts.xhtml';
+
+        let windows = Services.wm.getEnumerator(null);
+        while (windows.hasMoreElements()) {
+            let win = windows.getNext();
+            if (win.document.documentURI == url) {
+                win.focus();
+                return;
+            }
+        }
+
         let height = Math.min(window.screen.availHeight, 620);
         let features = 'chrome,centerscreen,titlebar,resizable,width=500,height=' + height;
-        let url = 'chrome://digest/content/keyboard-shortcuts.xhtml';
 
         window.openDialog(url, 'Digest shortcuts', features);
     }


### PR DESCRIPTION
Ending with multiples windows for the same dialog isn't hard to trigger using not modal windows (by default in linux, **browser.preferences.instantApply** preference is true).
