### PR TITLE
Fix alignment of toolbar button's unread counter

### DIFF
--- a/chrome/content/brief-overlay.xul
+++ b/chrome/content/brief-overlay.xul
@@ -93,7 +93,7 @@
                        tooltip="brief-tooltip"
                        context="brief-status-context"
                        onclick="if (event.button == 0 || event.button == 1) Brief.open()">
-            <hbox id="brief-button-inner-box">
+            <hbox id="brief-button-inner-box" align="center">
                 <vbox align="center">
                     <image class="toolbarbutton-icon"/>
                     <label class="toolbarbutton-text" crop="right" flex="1"/>


### PR DESCRIPTION
Misalignment is evident having text mode for toolbars, or in linux with (not small) icon mode.
